### PR TITLE
修复可能导致无法识别皮肤地址的问题

### DIFF
--- a/src/Controllers/ConfigController.php
+++ b/src/Controllers/ConfigController.php
@@ -20,10 +20,10 @@ class ConfigController extends Controller
         // - Specified by option 'site_url'
         // - Extract host from current URL
         $extra = option('ygg_skin_domain') === '' ? [] : explode(',', option('ygg_skin_domain'));
-        $skinDomains = array_map('trim', array_unique(array_merge($extra, [
+        $skinDomains = array_map('trim', array_values(array_unique(array_merge($extra, [
             parse_url(option('site_url'), PHP_URL_HOST),
             $request->getHost()
-        ])));
+        ]))));
 
         $privateKey = openssl_pkey_get_private(option('ygg_private_key'));
 


### PR DESCRIPTION
- 如果原本皮肤来源地址中包含2个以及上相同的地址，但在其后还有其他地址，将会在array_unique()去重时保留索引
后期输出json时因为带有有序索引，会将索引一并输出，导致AI无法识别